### PR TITLE
pypi install-ability

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
-include pywfa/*
 recursive-include pywfa WFA2_lib
+include _custom_build.py
+include pywfa/*
 include pywfa/tests/*
+include pywfa/WFA2_lib/*
 include pywfa/WFA2_lib/*/*

--- a/_custom_build.py
+++ b/_custom_build.py
@@ -74,7 +74,7 @@ print("Include dirs", include_dirs)
 # this has happened on multiple OS with/without `libomp-dev`
 # compiler = ccompiler.new_compiler()
 omp = 0 #1 if has_flag(compiler, "-fopenmp") else 0
-ret = run(f"cd pywfa/WFA2_lib; make clean all BUILD_WFA_PARALLEL={omp} BUILD_MINIMAL=1; cd ../../", shell=True)
+ret = run(f"cd pywfa/WFA2_lib; make clean all BUILD_WFA_PARALLEL={omp} BUILD_MINIMAL=1", shell=True)
 if ret.returncode != 0:
     print("Unable to build WFA2_lib")
     print(ret)

--- a/_custom_build.py
+++ b/_custom_build.py
@@ -56,15 +56,16 @@ def get_extra_args(flags):
 ##################
 # WFA2_lib build #
 ##################
-extras = ["-Wno-unused-function", "-Wno-unused-result", '-Wno-ignored-qualifiers', "-Wno-deprecated-declarations"]
+extras = ["-Wno-unused-function", "-Wno-unused-result",
+          "-Wno-ignored-qualifiers", "-Wno-deprecated-declarations"]
 extras_pywfa = get_extra_args(extras)
 
 root = os.path.abspath(os.path.dirname(__file__))
 wfa = os.path.join(root, "pywfa/WFA2_lib")
 libraries = [f"{wfa}/lib"]
 library_dirs = [f"{wfa}/lib"]
-include_dirs = [".", root, wfa, f"{wfa}/lib", f"{wfa}/utils", f"{wfa}/wavefront", f"{wfa}/bindings/cpp", f"{wfa}/system",
-                f"{wfa}/alignment", f"{root}/pywfa"]
+include_dirs = [".", root, wfa, f"{wfa}/lib", f"{wfa}/utils", f"{wfa}/wavefront",
+                f"{wfa}/bindings/cpp", f"{wfa}/system", f"{wfa}/alignment", f"{root}/pywfa"]
 
 print("Libs", libraries)
 print("Library dirs", library_dirs)
@@ -74,7 +75,8 @@ print("Include dirs", include_dirs)
 # this has happened on multiple OS with/without `libomp-dev`
 # compiler = ccompiler.new_compiler()
 omp = 0 #1 if has_flag(compiler, "-fopenmp") else 0
-ret = run(f"cd pywfa/WFA2_lib; make clean all BUILD_WFA_PARALLEL={omp} BUILD_MINIMAL=1", shell=True)
+ret = run(f"cd pywfa/WFA2_lib; make clean all BUILD_WFA_PARALLEL={omp} BUILD_MINIMAL=1",
+          shell=True)
 if ret.returncode != 0:
     print("Unable to build WFA2_lib")
     print(ret)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,6 @@ classifiers=[
 py-modules=["_custom_build"]
 packages=["pywfa", "pywfa.tests", "pywfa.WFA2_lib"]
 
-#[tool.setuptools.package-data]
-#pywfa=["_custom_build.py"]
-#"pywfa.WFA2_lib"=["pywfa/WFA2_lib/LICENSE", "pywfa/WFA2_lib/Makefile", "pywfa/WFA2_lib/README.md", "pywfa/WFA2_lib/VERSION"]
-
 [tool.setuptools.cmdclass]
 build_py="_custom_build.build_py"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,25 +4,29 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name="pywfa"
-version='0.4.2'
+version='0.5.0-dev1'
 description="Align sequences using WFA2-lib"
 requires-python='>=3.7'
-readme = "README.rst"
-authors = [
+readme="README.rst"
+authors=[
     { name = "Kez Cleal", email = "clealk@cardiff.ac.uk" }
 ]
-classifiers = [
+classifiers=[
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
 
 [tool.setuptools]
-py-modules = ["_custom_build"]
+py-modules=["_custom_build"]
 packages=["pywfa", "pywfa.tests", "pywfa.WFA2_lib"]
 
+#[tool.setuptools.package-data]
+#pywfa=["_custom_build.py"]
+#"pywfa.WFA2_lib"=["pywfa/WFA2_lib/LICENSE", "pywfa/WFA2_lib/Makefile", "pywfa/WFA2_lib/README.md", "pywfa/WFA2_lib/VERSION"]
+
 [tool.setuptools.cmdclass]
-build_py = "_custom_build.build_py"
+build_py="_custom_build.build_py"
 
 [project.urls]
 Repository="https://github.com/kcleal/pywfa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name="pywfa"
-version='0.5.0-dev1'
+version='0.5.0'
 description="Align sequences using WFA2-lib"
 requires-python='>=3.7'
 readme="README.rst"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,3 @@
 from setuptools import setup, find_packages
 
-setup(name="pywfa",
-      version="0.5.0-dev1",)
-      #data_files=[('.',["_custom_build.py"])],
-      #package_data = {'':["_custom_build.py"]},
-      #include_package_data=True)
+setup(name="pywfa", version="0.5.0-dev1")

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+from setuptools import setup, find_packages
+
+setup(name='pywfa',
+      version='0.4.2',
+      packages=find_packages(),
+     )

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-setup(name="pywfa", version="0.5.0-dev1")
+setup(name="pywfa", version="0.5.0")

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,7 @@
 from setuptools import setup, find_packages
 
-setup()
+setup(name="pywfa",
+      version="0.5.0-dev1",)
+      #data_files=[('.',["_custom_build.py"])],
+      #package_data = {'':["_custom_build.py"]},
+      #include_package_data=True)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
+from setuptools import setup, find_packages
 
-import setuptools
-
-if __name__ == "__main__":
-    setuptools.setup()
+setup()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
-from setuptools import setup, find_packages
+#!/usr/bin/env python
 
-setup(name='pywfa',
-      version='0.4.2',
-      packages=find_packages(),
-     )
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
Hello,

Turns out there was more to be done. The tl;dr; is that we still need a shim `setup.py`, and a few other things changed. 

When I tried to install pywfa for a package feature I'm testing, the github action that tests my package wasn't able to *successfully* install pywfa==0.4.2. I was getting an error that pywfa was named "UNKNOWN-0.0.0" 

<details>
<summary>full error</summary>

```
WARNING: Generating metadata for package pywfa produced metadata for project name unknown. Fix your #egg=pywfa fragments.
Discarding https://files.pythonhosted.org/packages/5d/92/366a9f0a0a4b34e2650199861a377eddf7e9f24ecc5298efb81352dc7cee/pywfa-0.4.2.tar.gz#sha256=065c782aa917da52c947a7ea1ed9d0e0153325153f7fcc32cca588f08e58136b (from https://pypi.org/simple/pywfa/) (requires-python:>=3.7): Requested unknown from https://files.pythonhosted.org/packages/5d/92/366a9f0a0a4b34e2650199861a377eddf7e9f24ecc5298efb81352dc7cee/pywfa-0.4.2.tar.gz#sha256=065c782aa917da52c947a7ea1ed9d0e0153325153f7fcc32cca588f08e58136b has inconsistent name: filename has 'pywfa', but metadata has 'unknown'
```
</details>

I also needed to fix the `MANIFEST.in` to include the `_custom_build.py` and Makefile in `pywfa/WFA2_lib/*`. Also, the new `_custom_build.py` has a check to ensure that the make command works. However, the make command never exited non-zero due to only returning the status of the final command (was `cd pywfa/WFA2_lib; make .. ; cd ../`).

I believe these changes should work better because I was able to get `python3 setup.py sdist` to create a valid, usable `python3 -m pip install dist/pywfa-0.5.0.dev1.tar.gz`.  And by having the shim, things like `pip install -e` seem to work. Furthermore, I successfully tested by editing my github action to pull directly via: `python3 -m pip install 'pywfa @ git+https://github.com/ACEnglish/pywfa'`. Which is great, but I don't know if this is a great emulation of what pypi will make.

Finally, I bumped the version to 0.5.0-dev. At least once trying  to install 0.4.2 failed and pip slyly installed 0.4.1 instead (which had caused the old `undefined symbol: wavefront_align`). I'm guessing that bumping the minor version instead of the patch may prevent this.

I don't know your workflow for distributing to pypi, but if possible, could you try a test.pypi.org upload before pushing to regular pypi? If there's more problems, we'll at least not be filling it up with my mistakes lol. 

Have a great day,
~/Adam English
